### PR TITLE
Fix breaking change with 3.0 update

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,15 +1,9 @@
-import { defineConfig, sharpImageService } from 'astro/config';
+import { defineConfig } from 'astro/config';
 import { SITE_URL } from './src/consts';
 
 export default defineConfig({
     site: SITE_URL,
-    experimental: {
-        assets: true
-    },
     build: {
-        inlineStylesheets: "always",
+        inlineStylesheets: 'always',
     },
-    image: {
-        service: sharpImageService(),
-    }
 });


### PR DESCRIPTION
https://docs.astro.build/en/guides/upgrade-to/v3/#astro-v30-experimental-flags-removed